### PR TITLE
Change Lightning profile name to CSGOV

### DIFF
--- a/csgov.info.yml
+++ b/csgov.info.yml
@@ -1,4 +1,4 @@
-name: Lightning
+name: CSGOV
 core: 8.x
 type: profile
 description: 'A feature-rich Drupal distribution for czech and slovak eGovernment sites.' 


### PR DESCRIPTION
Change Lightning installation profile name to CSGOV.